### PR TITLE
将固定20s改为固定60s

### DIFF
--- a/main.js
+++ b/main.js
@@ -46,10 +46,10 @@ function Close(){
 }
 
 function CloseAd(caption){
-    toastLog("看视频等待20s" + caption)
-    sleep(20000)
+    toastLog("看视频等待60s" + caption)
+    sleep(60000)
     Close()  
-    sleep(2000)
+    sleep(6000)
     toastLog("查找开心收下")
     var meButton =text("开心收下").findOnce()
     if (meButton != undefined){
@@ -57,7 +57,7 @@ function CloseAd(caption){
         meButton.click()
     }               
     toastLog("看视频结束: " + caption) 
-    sleep(2000)
+    sleep(6000)
 }
 
 function ClickAd8(){


### PR DESCRIPTION
因为视频加载需要时间（可能超过5s），固定20s可能会是观看视频时间不足15s，从而需要手动点击。
因为是自动化脚本，所以延长固定时间对于用户的影响可以忽略不记。